### PR TITLE
Update load-utils to use getOptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Apply this set of loaders to your `webpack.config.js`:
 ```js
 {
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.hbs$/,
         include: /app\/templates/, // or whatever directory you have
@@ -66,10 +66,17 @@ Example:
 ```js
 {
   module: {
-    loaders: [
+    rules: [
       {
         test: /app\/index\.js/,
-        loader: 'ember-webpack-loaders/inject-templates-loader!ember-webpack-loaders/inject-modules-loader',
+        use: [ 
+          {
+            loader: 'ember-webpack-loaders/inject-templates-loader'
+          },
+          {
+            loader: 'ember-webpack-loaders/inject-modules-loader',
+          }
+        ],
         options: {
           appVar: 'MyProject'
         }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Check the example app here: https://github.com/tulios/ember-webpack-example
 
 Check the rails 5.1 app using these loaders https://github.com/rajibahmed/ember-react-webpack-rails-demo
 
+Use VERSION 0.2.0 if you're using webpack1 https://github.com/tulios/ember-webpack-loaders/tree/0.2.0
+
 ## Install
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A set of webpack loaders to help with ember integration.
 
 Check the example app here: https://github.com/tulios/ember-webpack-example
 
+Check the rails 5.1 app using these loaders https://github.com/rajibahmed/ember-react-webpack-rails-demo
+
 ## Install
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -25,8 +25,21 @@ Apply this set of loaders to your `webpack.config.js`:
       },
       {
         test: /app\/index\.js/, // the main app file
-        loader: 'ember-webpack-loaders/inject-templates-loader!ember-webpack-loaders/inject-modules-loader'
-      }
+        use: [
+            {
+              loader: 'ember-webpack-loaders/inject-templates-loader',
+              options: {
+                appPath: './path/to/app',
+              }
+            },
+            {
+              loader: 'ember-webpack-loaders/inject-modules-loader',
+              options: {
+                appPath: './path/to/app',
+              }
+            }
+         ],
+       }
     ]
   }
 }
@@ -57,7 +70,7 @@ Example:
       {
         test: /app\/index\.js/,
         loader: 'ember-webpack-loaders/inject-templates-loader!ember-webpack-loaders/inject-modules-loader',
-        query: {
+        options: {
           appVar: 'MyProject'
         }
       }

--- a/htmlbars-loader.js
+++ b/htmlbars-loader.js
@@ -12,8 +12,8 @@ var appPath
  *  - templateCompiler: default 'components-ember/ember-template-compiler.js'
  */
 module.exports = function(source) {
-	this.cacheable && this.cacheable()
-	var options = loaderUtils.getOptions(this);
+  this.cacheable && this.cacheable()
+  var options = loaderUtils.getOptions(this);
   var appPath = (options.appPath || 'app').replace(/\/$/, '')
   var templatesFolder = path.join(appPath, 'templates')
 

--- a/htmlbars-loader.js
+++ b/htmlbars-loader.js
@@ -12,8 +12,8 @@ var appPath
  *  - templateCompiler: default 'components-ember/ember-template-compiler.js'
  */
 module.exports = function(source) {
-  this.cacheable && this.cacheable()
-  var options = loaderUtils.parseQuery(this.query);
+	this.cacheable && this.cacheable()
+	var options = loaderUtils.getOptions();
   var appPath = (options.appPath || 'app').replace(/\/$/, '')
   var templatesFolder = path.join(appPath, 'templates')
 

--- a/htmlbars-loader.js
+++ b/htmlbars-loader.js
@@ -13,7 +13,7 @@ var appPath
  */
 module.exports = function(source) {
 	this.cacheable && this.cacheable()
-	var options = loaderUtils.getOptions();
+	var options = loaderUtils.getOptions(this);
   var appPath = (options.appPath || 'app').replace(/\/$/, '')
   var templatesFolder = path.join(appPath, 'templates')
 

--- a/inject-modules-loader.js
+++ b/inject-modules-loader.js
@@ -9,7 +9,7 @@ var recursive = require('recursive-readdir-sync')
  *  - appVar: default App
  */
 module.exports = function(source) {
-  var options = loaderUtils.parseQuery(this.query);
+  var options = loaderUtils.getOptions();
   var appPath = (options.appPath || 'app').replace(/\/$/, '')
   appPath = path.resolve(appPath)
   var appVar = options.appVar || 'App'

--- a/inject-modules-loader.js
+++ b/inject-modules-loader.js
@@ -9,7 +9,7 @@ var recursive = require('recursive-readdir-sync')
  *  - appVar: default App
  */
 module.exports = function(source) {
-  var options = loaderUtils.getOptions();
+  var options = loaderUtils.getOptions(this);
   var appPath = (options.appPath || 'app').replace(/\/$/, '')
   appPath = path.resolve(appPath)
   var appVar = options.appVar || 'App'

--- a/inject-templates-loader.js
+++ b/inject-templates-loader.js
@@ -7,7 +7,7 @@ var recursive = require('recursive-readdir-sync')
  *  - appPath: default assuming webpack.config.js in root folder + ./app
  */
 module.exports = function(source) {
-  var options = loaderUtils.parseQuery(this.query);
+  var options = loaderUtils.getOptions();
   var appPath = (options.appPath || 'app').replace(/\/$/, '')
   appPath = path.resolve(appPath)
   var templatesFolder = path.join(appPath, 'templates')

--- a/inject-templates-loader.js
+++ b/inject-templates-loader.js
@@ -7,7 +7,7 @@ var recursive = require('recursive-readdir-sync')
  *  - appPath: default assuming webpack.config.js in root folder + ./app
  */
 module.exports = function(source) {
-  var options = loaderUtils.getOptions();
+  var options = loaderUtils.getOptions(this);
   var appPath = (options.appPath || 'app').replace(/\/$/, '')
   appPath = path.resolve(appPath)
   var templatesFolder = path.join(appPath, 'templates')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Tulio Ornelas <ornelas.tulio@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "components-ember": "https://github.com/components/ember/tarball/2.2.0",
+    "components-ember": "https://github.com/components/ember/tarball/2.7.2",
     "ember-cli-htmlbars": "^1.0.2",
     "loader-utils": "^1.0.0",
     "recursive-readdir-sync": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "components-ember": "https://github.com/components/ember/tarball/2.2.0",
     "ember-cli-htmlbars": "^1.0.2",
-    "loader-utils": "1.1.0",
+    "loader-utils": "^1.0.0",
     "recursive-readdir-sync": "^1.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "components-ember": "https://github.com/components/ember/tarball/2.2.0",
     "ember-cli-htmlbars": "^1.0.2",
-    "loader-utils": "^0.2.12",
+    "loader-utils": "1.1.0",
     "recursive-readdir-sync": "^1.0.6"
   }
 }


### PR DESCRIPTION
load-utils is deprecating parseQuery in favour of getOptions method. 
readmore here https://github.com/webpack/loader-utils/issues/56

getOptions will fallback to queryString internally. So, getOptions is backward compatible.
